### PR TITLE
Change 'modern.js' export path to 'modern.mjs'

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "main": "lib/preact-merge-refs.js",
   "module": "lib/preact-merge-refs.module.js",
-  "exports": "./lib/preact-merge-refs.modern.js",
+  "exports": "./lib/preact-merge-refs.modern.mjs",
   "unpkg": "./lib/preact-merge-refs.umd.js",
   "types": "./lib/types/index.d.ts",
   "files": [


### PR DESCRIPTION
For Node and other tools to import a JS file as an ES module, either the file must end with .mjs, or the package's package.json should contain '"type": "module"'.

See https://nodejs.org/docs/latest/api/esm.html#esm_differences_between_es_modules_and_commonjs.

This commit does the former, which felt like the least disruptive.

Currently, this package cannot be imported as an ES module, by tools that follow our package.json's 'exports' path.